### PR TITLE
Allow passing search parameter in URL

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -62,7 +62,7 @@ def handle_request():
     elif mode == 'choose_profile':
         connect.choose_profile()
     elif mode == 'search':
-        search.netflix(video_type)
+        search.netflix(video_type, url)
     elif mode == 'delete_cookies':
         delete.cookies()
     elif mode == 'delete_cache':

--- a/resources/search.py
+++ b/resources/search.py
@@ -10,8 +10,9 @@ tmdbsimple.API_KEY = base64.b64decode('NDc2N2I0YjJiYjk0YjEwNGZhNTUxNWM1ZmY0ZTFmZ
 language = generic_utility.get_setting('language').split('-')[0]
 
 
-def netflix(video_type):
-    search_string = generic_utility.keyboard()
+def netflix(video_type, search_string=None):
+    if not search_string:
+        search_string = generic_utility.keyboard()
     if search_string:
         list.search(search_string, video_type)
 


### PR DESCRIPTION
This allows easy compatibility with the Meta Kodi addon. Meta allows searching content in multiple addons, local folders and
local library at once. Most addons are compatible with it and adding flix2kodi would be great (the changes are really minor). 

See: https://github.com/metate/meta4kodi
